### PR TITLE
Fix mock builds

### DIFF
--- a/pytorch.spec
+++ b/pytorch.spec
@@ -1,23 +1,28 @@
+%global debug_package %{nil}
 %global toolchain clang
 
 Summary:        An AI/ML python package
 Name:           pytorch
 License:        TBD
 Version:        2.0.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 
 URL:            https://github.com/pytorch/pytorch
 Source0:        %{url}/releases/download/v%{version}/%{name}-v%{version}.tar.gz
 Patch0:         0001-Include-stdexcept.patch
 Patch1:         0001-Include-stdint.h.patch
 
-ExclusiveArch:  x86_64
-
 BuildRequires:  blas-static
+BuildRequires:  clang-devel
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
 BuildRequires:  lapack-static
 BuildRequires:  make
+BuildRequires:  protobuf-devel
+BuildRequires:  python3-pybind11
+BuildRequires:  python3-pyyaml
+BuildRequires:  python3-typing-extensions
+
 # TBD : add more
 
 %description
@@ -52,6 +57,9 @@ for %{name}.
         -DUSE_MKLDNN=OFF \
 	-DUSE_NNPACK=OFF \
 	-DUSE_TENSORPIPE=OFF \
+        -DBUILD_CUSTOM_PROTOBUF=OFF \
+        -DCAFFE2_LINK_LOCAL_PROTOBUF=OFF \
+        -DUSE_SYSTEM_PYBIND11=ON \
 	-DUSE_XNNPACK=OFF
 
 %cmake_build
@@ -60,12 +68,71 @@ for %{name}.
 %cmake_install
 
 %files
+%{_datadir}/ATen
+%{_datadir}/cmake/ATen
+%{_datadir}/cmake/Caffe2
+%{_datadir}/cmake/Torch
+
+/usr/lib/libc10.so
+/usr/lib/libtorch.so
+/usr/lib/libtorch_cpu.so
+/usr/lib/libtorch_global_deps.so
+%{_libdir}/libCaffe2_perfkernels_avx.a
+%{_libdir}/libCaffe2_perfkernels_avx2.a
+%{_libdir}/libCaffe2_perfkernels_avx512.a
+
+# FIXME: coming from third_party 
+# cpuinfo
+%{_libdir}/libclog.a
+%{_libdir}/libcpuinfo.a
+%{_libdir}/pkgconfig/libcpuinfo.pc
+%{_datadir}/cpuinfo
+
+# pthreadpool
+%{_libdir}/libpthreadpool.a
+
+# QNNPACK
+%{_libdir}/libpytorch_qnnpack.a
+%{_libdir}/libqnnpack.a
+
+# sleef
+%{_libdir}/libsleef.a
+%{_libdir}/pkgconfig/sleef.pc
 
 %files devel
+%{_includedir}/ATen
+%{_includedir}/c10
 %{_includedir}/torch
+%{_includedir}/caffe2
 
+# FIXME: coming from third_party
+# cpuinfo
+%{_includedir}/clog.h
+%{_includedir}/cpuinfo.h
+
+# FP16
+%{_includedir}/fp16.h
+%{_includedir}/fp16
+
+# FXdiv
+%{_includedir}/fxdiv.h
+
+# psmid
+%{_includedir}/psimd.h
+
+# pthreadpool
+%{_includedir}/pthreadpool.h
+
+# QNNPACK
+%{_includedir}/qnnpack.h
+%{_includedir}/qnnpack_func.h
+
+# sleef
+%{_includedir}/sleef.h
 
 %changelog
+* Mon Jul 31 2023 Jason Montleon <jmontleo@redhat.com> - 2.0.1-2
+- Improvements to get building in mock
+
 * Sat Jul 29 2023 Tom Rix <trix@redhat.com> - 2.0.1-1
 - Stub something together
-

--- a/pytorch.spec
+++ b/pytorch.spec
@@ -12,12 +12,17 @@ Source0:        %{url}/releases/download/v%{version}/%{name}-v%{version}.tar.gz
 Patch0:         0001-Include-stdexcept.patch
 Patch1:         0001-Include-stdint.h.patch
 
+%if 0%{?fedora}
 BuildRequires:  blas-static
+%endif
 BuildRequires:  clang-devel
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
 BuildRequires:  lapack-static
 BuildRequires:  make
+%if 0%{?rhel}
+BuildRequires:  openblas-static
+%endif
 BuildRequires:  protobuf-devel
 BuildRequires:  python3-pybind11
 BuildRequires:  python3-pyyaml


### PR DESCRIPTION
With these changes pytorch will at least build under mock. I'm not sure why some of the libraries are landing under /usr/lib instead of /lib64.

Please also see https://copr.fedorainfracloud.org/coprs/rezso/ML/packages/ for another individual who has gotten quite far, especially when it comes to breaking out the third party libraries.