### PR TITLE
Fix ppc64le builds

### DIFF
--- a/do-not-force-Werror-on-Pooling.patch
+++ b/do-not-force-Werror-on-Pooling.patch
@@ -1,0 +1,23 @@
+From 7308e5359edc9e9ebd8466ee7ab0f48be1583a3f Mon Sep 17 00:00:00 2001
+From: Nikita Shulga <nshulga@meta.com>
+Date: Fri, 28 Jul 2023 07:08:59 -0700
+Subject: [PATCH] Do not force -Werror on Pooling.cpp
+
+As new versions of compilers are likely find new types of violation s as shown in https://github.com/pytorch/pytorch/issues/105728
+---
+ caffe2/CMakeLists.txt | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/caffe2/CMakeLists.txt b/caffe2/CMakeLists.txt
+index cc6ecdc7415f67..955bc67e2299c9 100644
+--- a/caffe2/CMakeLists.txt
++++ b/caffe2/CMakeLists.txt
+@@ -530,8 +530,6 @@ endif()
+ # Required workaround for LLVM 9 includes.
+ if(NOT MSVC)
+   set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_jit.cpp PROPERTIES COMPILE_FLAGS -Wno-noexcept-type)
+-  # Force -Werror on several files
+-  set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/mkldnn/Pooling.cpp PROPERTIES COMPILE_FLAGS "-Werror")
+ endif()
+ # Disable certain warnings for GCC-9.X
+ if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0.0))

--- a/fallback-to-cpu_kernel-for-VSX.patch
+++ b/fallback-to-cpu_kernel-for-VSX.patch
@@ -1,0 +1,75 @@
+diff --git a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int16_vsx.h b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int16_vsx.h
+index 7c300c8087cff2..a71f50fc7aaa30 100644
+--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int16_vsx.h
++++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int16_vsx.h
+@@ -334,6 +334,20 @@ class Vectorized<int16_t> {
+   DEFINE_MEMBER_OP(operator^, int16_t, vec_xor)
+ };
+ 
++template <>
++Vectorized<int16_t> inline operator<<(const Vectorized<int16_t>& a, const Vectorized<int16_t>& b) {
++               vuint16 shift_vec0 = reinterpret_cast<vuint16>(b.vec0());
++               vuint16 shift_vec1 = reinterpret_cast<vuint16>(b.vec1());
++         return Vectorized<int16_t>{vec_sl(a.vec0(), shift_vec0), vec_sl(a.vec1(), shift_vec1)};
++}
++
++template <>
++Vectorized<int16_t> inline operator>>(const Vectorized<int16_t>& a, const Vectorized<int16_t>& b) {
++               vuint16 shift_vec0 = reinterpret_cast<vuint16>(b.vec0());
++               vuint16 shift_vec1 = reinterpret_cast<vuint16>(b.vec1()) ;
++         return Vectorized<int16_t>{vec_sr(a.vec0(), shift_vec0), vec_sr(a.vec1(), shift_vec1)};
++}
++
+ template <>
+ Vectorized<int16_t> inline maximum(
+     const Vectorized<int16_t>& a,
+diff --git a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int32_vsx.h b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int32_vsx.h
+index c98ab6215e6206..1b6a82df39b530 100644
+--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int32_vsx.h
++++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int32_vsx.h
+@@ -265,6 +265,20 @@ class Vectorized<int32_t> {
+   DEFINE_MEMBER_OP(operator^, int32_t, vec_xor)
+ };
+ 
++template <>
++Vectorized<int32_t> inline operator<<(const Vectorized<int32_t>& a, const Vectorized<int32_t>& b) {
++                vuint32 shift_vec0 = reinterpret_cast<vuint32>(b.vec0());
++                vuint32 shift_vec1 = reinterpret_cast<vuint32>(b.vec1()) ;
++          return Vectorized<int32_t>{vec_sl(a.vec0(), shift_vec0), vec_sl(a.vec1(), shift_vec1)};
++}
++
++template <>
++Vectorized<int32_t> inline operator>>(const Vectorized<int32_t>& a, const Vectorized<int32_t>& b) {
++                vuint32 shift_vec0 = reinterpret_cast<vuint32>(b.vec0());
++                vuint32 shift_vec1 = reinterpret_cast<vuint32>(b.vec1()) ;
++          return Vectorized<int32_t>{vec_sr(a.vec0(), shift_vec0), vec_sr(a.vec1(), shift_vec1)};
++}
++
+ template <>
+ Vectorized<int32_t> inline maximum(
+     const Vectorized<int32_t>& a,
+diff --git a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int64_vsx.h b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int64_vsx.h
+index a4171026a2b99f..a7a376ee16ec54 100644
+--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int64_vsx.h
++++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_int64_vsx.h
+@@ -217,6 +217,20 @@ class Vectorized<int64_t> {
+   DEFINE_MEMBER_OP(operator^, int64_t, vec_xor)
+ };
+ 
++template <>
++Vectorized<int64_t> inline operator<<(const Vectorized<int64_t>& a, const Vectorized<int64_t>& b) {
++                vuint64 shift_vec0 = reinterpret_cast<vuint64>(b.vec0());
++                vuint64 shift_vec1 = reinterpret_cast<vuint64>(b.vec1()) ;
++          return Vectorized<int64_t>{vec_sl(a.vec0(), shift_vec0), vec_sl(a.vec1(), shift_vec1)};
++}
++
++template <>
++Vectorized<int64_t> inline operator>>(const Vectorized<int64_t>& a, const Vectorized<int64_t>& b) {
++                vuint64 shift_vec0 = reinterpret_cast<vuint64>(b.vec0());
++                vuint64 shift_vec1 = reinterpret_cast<vuint64>(b.vec1()) ;
++          return Vectorized<int64_t>{vec_sr(a.vec0(), shift_vec0), vec_sr(a.vec1(), shift_vec1)};
++}
++
+ template <>
+ Vectorized<int64_t> inline maximum(
+     const Vectorized<int64_t>& a,

--- a/fix-cpuinfo-implicit-syscall.patch
+++ b/fix-cpuinfo-implicit-syscall.patch
@@ -1,0 +1,15 @@
+commit 9319defe0ec044dddb3ecec80a798935716807fb
+Author: Jason Montleon <jmontleo@redhat.com>
+Date:   Fri Aug 4 11:06:20 2023 -0400
+
+    Fix implicit syscall on ppc64le and aarch64
+
+diff --git a/third_party/cpuinfo/src/api.c b/third_party/cpuinfo/src/api.c
+index f91b421..a560938 100644
+--- a/third_party/cpuinfo/src/api.c
++++ b/third_party/cpuinfo/src/api.c
+@@ -1,3 +1,4 @@
++#define _GNU_SOURCE
+ #include <stdbool.h>
+ #include <stddef.h>
+ 


### PR DESCRIPTION
Fixes https://github.com/trixirt/pytorch-fedora/issues/4

I think clang is going to be a challenge to get working on powerpc. If I understand correctly from conversations elsewhere it brings its own `altivec.h` on this platform which causes lots of pain.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97163
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=239266

The two new patches come from:
https://github.com/pytorch/pytorch/commit/bb0b283e5ace42b65a6180956bdff6af1b560e4c
https://github.com/pytorch/pytorch/pull/98511 (not merged yet)

Also included the missing implicit syscall patch from the s390x PR.

https://copr.fedorainfracloud.org/coprs/jmontleon/pytorch/build/6245649/ shows results for the version of the spec in this PR